### PR TITLE
Avoid cloning of frame instance

### DIFF
--- a/gaf/src/com/catalystapps/gaf/data/config/CAnimationFrame.as
+++ b/gaf/src/com/catalystapps/gaf/data/config/CAnimationFrame.as
@@ -48,7 +48,7 @@ package com.catalystapps.gaf.data.config
 			
 			for each(var instance: CAnimationFrameInstance in this._instances)
 			{
-				result.addInstance(instance.clone());
+				result.addInstance(instance);
 			}
 			
 			return result;


### PR DESCRIPTION
Hi,

I have carefully looked at the code and I think this clone() operation is useless. It seems to waste memory and cpu time.
