### PR TITLE
Handle lost context on android devices in properly way.

### DIFF
--- a/gaf/src/com/catalystapps/gaf/core/ZipToGAFAssetConverter.as
+++ b/gaf/src/com/catalystapps/gaf/core/ZipToGAFAssetConverter.as
@@ -573,9 +573,10 @@ package com.catalystapps.gaf.core
 				else
 				{
 					this.gfxData.removeImages();
-					for each (var bd: BitmapData in this.pngImgs)
-					{
-						bd.dispose();
+					if (!Starling.handleLostContext) {
+						for each (var bd : BitmapData in this.pngImgs) {
+							bd.dispose();
+						}
 					}
 					this.pngImgs = null;
 				}


### PR DESCRIPTION
When starling trying to handle lost context on android, it gets error when restoring textures that was created from bitmaps. because that bitmaps were disposed. BUT there maybe memory leaks (mb they doesn't, i didn't check yet).