### PR TITLE
isNaN without memory allocations

### DIFF
--- a/gaf/src/com/catalystapps/gaf/core/ZipToGAFAssetConverter.as
+++ b/gaf/src/com/catalystapps/gaf/core/ZipToGAFAssetConverter.as
@@ -387,11 +387,11 @@ package com.catalystapps.gaf.core
 
 					for each (var scale: CTextureAtlasScale in config.allTextureAtlases)
 					{
-						if (isNaN(this._defaultScale) || MathUtility.equals(scale.scale, this._defaultScale))
+						if (MathUtility.isNaN(this._defaultScale) || MathUtility.equals(scale.scale, this._defaultScale))
 						{
 							for each (var csf: CTextureAtlasCSF in scale.allContentScaleFactors)
 							{
-								if (isNaN(this._defaultContentScaleFactor) || MathUtility.equals(csf.csf, this._defaultContentScaleFactor))
+								if (MathUtility.isNaN(this._defaultContentScaleFactor) || MathUtility.equals(csf.csf, this._defaultContentScaleFactor))
 								{
 									for each (var source: CTextureAtlasSource in csf.sources)
 									{
@@ -669,11 +669,11 @@ package com.catalystapps.gaf.core
 		{
 			for each (var cScale: CTextureAtlasScale in config.allTextureAtlases)
 			{
-				if (isNaN(this._defaultScale) || MathUtility.equals(this._defaultScale, cScale.scale))
+				if (MathUtility.isNaN(this._defaultScale) || MathUtility.equals(this._defaultScale, cScale.scale))
 				{
 					for each(var cCSF: CTextureAtlasCSF in cScale.allContentScaleFactors)
 					{
-						if (isNaN(this._defaultContentScaleFactor) || MathUtility.equals(this._defaultContentScaleFactor, cCSF.csf))
+						if (MathUtility.isNaN(this._defaultContentScaleFactor) || MathUtility.equals(this._defaultContentScaleFactor, cCSF.csf))
 						{
 							for each (var taSource: CTextureAtlasSource in cCSF.sources)
 							{

--- a/gaf/src/com/catalystapps/gaf/data/GAFAsset.as
+++ b/gaf/src/com/catalystapps/gaf/data/GAFAsset.as
@@ -3,7 +3,6 @@
  */
 package com.catalystapps.gaf.data
 {
-	import com.catalystapps.gaf.utils.MathUtility;
 	import com.catalystapps.gaf.core.gaf_internal;
 	import com.catalystapps.gaf.data.config.CTextureAtlasCSF;
 	import com.catalystapps.gaf.data.config.CTextureAtlasElement;
@@ -11,6 +10,7 @@ package com.catalystapps.gaf.data
 	import com.catalystapps.gaf.display.GAFScale9Texture;
 	import com.catalystapps.gaf.display.GAFTexture;
 	import com.catalystapps.gaf.display.IGAFTexture;
+	import com.catalystapps.gaf.utils.MathUtility;
 
 	import flash.geom.Matrix;
 
@@ -140,8 +140,8 @@ package com.catalystapps.gaf.data
 
 		gaf_internal function getCustomRegion(linkage: String, scale: Number = NaN, csf: Number = NaN): IGAFTexture
 		{
-			if (isNaN(scale)) scale = this._scale;
-			if (isNaN(csf)) csf = this._csf;
+			if (MathUtility.isNaN(scale)) scale = this._scale;
+			if (MathUtility.isNaN(csf)) csf = this._csf;
 
 			var gafTexture: IGAFTexture;
 			var atlasScale: CTextureAtlasScale;

--- a/gaf/src/com/catalystapps/gaf/data/GAFGFXData.as
+++ b/gaf/src/com/catalystapps/gaf/data/GAFGFXData.as
@@ -3,6 +3,7 @@ package com.catalystapps.gaf.data
 	import com.catalystapps.gaf.data.tagfx.ITAGFX;
 	import com.catalystapps.gaf.data.tagfx.TAGFXBase;
 	import com.catalystapps.gaf.utils.DebugUtility;
+	import com.catalystapps.gaf.utils.MathUtility;
 
 	import flash.display.BitmapData;
 	import flash.display3D.Context3DTextureFormat;
@@ -212,7 +213,7 @@ package com.catalystapps.gaf.data
 		 */
 		public function disposeTextures(scale: Number = NaN, csf: Number = NaN, imageID: String = null): void
 		{
-			if (isNaN(scale))
+			if (MathUtility.isNaN(scale))
 			{
 				for (var scaleToDispose: String in this._texturesDictionary)
 				{
@@ -223,7 +224,7 @@ package com.catalystapps.gaf.data
 			}
 			else
 			{
-				if (isNaN(csf))
+				if (MathUtility.isNaN(csf))
 				{
 					for (var csfToDispose: String in this._texturesDictionary[scale])
 					{

--- a/gaf/src/com/catalystapps/gaf/data/GAFTimeline.as
+++ b/gaf/src/com/catalystapps/gaf/data/GAFTimeline.as
@@ -1,15 +1,16 @@
 package com.catalystapps.gaf.data
 {
-	import com.catalystapps.gaf.data.converters.ErrorConstants;
 	import com.catalystapps.gaf.core.gaf_internal;
 	import com.catalystapps.gaf.data.config.CAnimationObject;
 	import com.catalystapps.gaf.data.config.CFrameSound;
 	import com.catalystapps.gaf.data.config.CTextureAtlas;
 	import com.catalystapps.gaf.data.config.CTextureAtlasCSF;
 	import com.catalystapps.gaf.data.config.CTextureAtlasScale;
+	import com.catalystapps.gaf.data.converters.ErrorConstants;
 	import com.catalystapps.gaf.display.IGAFTexture;
 	import com.catalystapps.gaf.sound.GAFSoundData;
 	import com.catalystapps.gaf.sound.GAFSoundManager;
+	import com.catalystapps.gaf.utils.MathUtility;
 
 	import flash.media.Sound;
 
@@ -332,7 +333,7 @@ package com.catalystapps.gaf.data
 		public function set scale(value: Number): void
 		{
 			var scale: Number = this._gafAsset.gaf_internal::getValidScale(value);
-			if (isNaN(scale))
+			if (MathUtility.isNaN(scale))
 			{
 				throw new Error(ErrorConstants.SCALE_NOT_FOUND);
 			}

--- a/gaf/src/com/catalystapps/gaf/data/converters/BinGAFAssetConfigConverter.as
+++ b/gaf/src/com/catalystapps/gaf/data/converters/BinGAFAssetConfigConverter.as
@@ -1,10 +1,7 @@
 package com.catalystapps.gaf.data.converters
 {
-	import com.catalystapps.gaf.data.GAF;
-	import flash.events.ErrorEvent;
 	import com.catalystapps.gaf.core.gaf_internal;
-	import com.catalystapps.gaf.data.config.CSound;
-	import starling.core.Starling;
+	import com.catalystapps.gaf.data.GAF;
 	import com.catalystapps.gaf.data.GAFAssetConfig;
 	import com.catalystapps.gaf.data.GAFTimelineConfig;
 	import com.catalystapps.gaf.data.config.CAnimationFrame;
@@ -14,6 +11,7 @@ package com.catalystapps.gaf.data.converters
 	import com.catalystapps.gaf.data.config.CBlurFilterData;
 	import com.catalystapps.gaf.data.config.CFilter;
 	import com.catalystapps.gaf.data.config.CFrameAction;
+	import com.catalystapps.gaf.data.config.CSound;
 	import com.catalystapps.gaf.data.config.CStage;
 	import com.catalystapps.gaf.data.config.CTextFieldObject;
 	import com.catalystapps.gaf.data.config.CTextureAtlasCSF;
@@ -23,6 +21,7 @@ package com.catalystapps.gaf.data.converters
 	import com.catalystapps.gaf.data.config.CTextureAtlasSource;
 	import com.catalystapps.gaf.utils.MathUtility;
 
+	import flash.events.ErrorEvent;
 	import flash.events.Event;
 	import flash.events.EventDispatcher;
 	import flash.geom.Matrix;
@@ -35,6 +34,7 @@ package com.catalystapps.gaf.data.converters
 	import flash.utils.Endian;
 	import flash.utils.getTimer;
 
+	import starling.core.Starling;
 	import starling.utils.RectangleUtil;
 
 	use namespace gaf_internal;
@@ -376,10 +376,10 @@ package com.catalystapps.gaf.data.converters
 
 			this.readMaskMaxSizes();
 
-			if (isNaN(this._config.defaultScale))
+			if (MathUtility.isNaN(this._config.defaultScale))
 			{
 				var itemIndex: int;
-				if (!isNaN(this._defaultScale))
+				if (!MathUtility.isNaN(this._defaultScale))
 				{
 					itemIndex = MathUtility.getItemIndex(this._config.scaleValues, this._defaultScale);
 					if (itemIndex < 0)
@@ -391,10 +391,10 @@ package com.catalystapps.gaf.data.converters
 				this._config.defaultScale = this._config.scaleValues[itemIndex];
 			}
 
-			if (isNaN(this._config.defaultContentScaleFactor))
+			if (MathUtility.isNaN(this._config.defaultContentScaleFactor))
 			{
 				itemIndex = 0;
-				if (!isNaN(this._defaultContentScaleFactor))
+				if (!MathUtility.isNaN(this._defaultContentScaleFactor))
 				{
 					itemIndex = MathUtility.getItemIndex(this._config.csfValues, this._defaultContentScaleFactor);
 					if (itemIndex < 0)
@@ -440,7 +440,7 @@ package com.catalystapps.gaf.data.converters
 
 		private function readAnimationFrames(tagID: int, startIndex: uint = 0, framesCount: Number = NaN, prevFrame: CAnimationFrame = null): void
 		{
-			if (isNaN(framesCount))
+			if (MathUtility.isNaN(framesCount))
 			{
 				framesCount = this._bytes.readUnsignedInt();
 			}

--- a/gaf/src/com/catalystapps/gaf/display/GAFImage.as
+++ b/gaf/src/com/catalystapps/gaf/display/GAFImage.as
@@ -3,6 +3,7 @@ package com.catalystapps.gaf.display
 	import com.catalystapps.gaf.core.gaf_internal;
 	import com.catalystapps.gaf.data.config.CFilter;
 	import com.catalystapps.gaf.filter.GAFFilter;
+	import com.catalystapps.gaf.utils.MathUtility;
 
 	import flash.geom.Matrix;
 	import flash.geom.Matrix3D;
@@ -208,7 +209,7 @@ package com.catalystapps.gaf.display
 		{
 			use namespace gaf_internal;
 
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -220,7 +221,7 @@ package com.catalystapps.gaf.display
 		{
 			use namespace gaf_internal;
 
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -232,7 +233,7 @@ package com.catalystapps.gaf.display
 		{
 			use namespace gaf_internal;
 
-			if (!isNaN(this.__debugOriginalAlpha))
+			if (!MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.alpha = this.__debugOriginalAlpha;
 				this.__debugOriginalAlpha = NaN;

--- a/gaf/src/com/catalystapps/gaf/display/GAFMovieClip.as
+++ b/gaf/src/com/catalystapps/gaf/display/GAFMovieClip.as
@@ -1,10 +1,8 @@
 package com.catalystapps.gaf.display
 {
-	import starling.events.Event;
-	import com.catalystapps.gaf.data.GAFAsset;
-	import com.catalystapps.gaf.data.config.CSound;
-	import com.catalystapps.gaf.data.GAF;
 	import com.catalystapps.gaf.core.gaf_internal;
+	import com.catalystapps.gaf.data.GAF;
+	import com.catalystapps.gaf.data.GAFAsset;
 	import com.catalystapps.gaf.data.GAFDebugInformation;
 	import com.catalystapps.gaf.data.GAFTimeline;
 	import com.catalystapps.gaf.data.GAFTimelineConfig;
@@ -14,10 +12,12 @@ package com.catalystapps.gaf.display
 	import com.catalystapps.gaf.data.config.CAnimationSequence;
 	import com.catalystapps.gaf.data.config.CFilter;
 	import com.catalystapps.gaf.data.config.CFrameAction;
+	import com.catalystapps.gaf.data.config.CSound;
 	import com.catalystapps.gaf.data.config.CTextFieldObject;
 	import com.catalystapps.gaf.data.config.CTextureAtlas;
 	import com.catalystapps.gaf.filter.GAFFilter;
 	import com.catalystapps.gaf.utils.DebugUtility;
+	import com.catalystapps.gaf.utils.MathUtility;
 
 	import flash.errors.IllegalOperationError;
 	import flash.events.ErrorEvent;
@@ -33,6 +33,7 @@ package com.catalystapps.gaf.display
 	import starling.display.Quad;
 	import starling.display.QuadBatch;
 	import starling.display.Sprite;
+	import starling.events.Event;
 	import starling.textures.TextureSmoothing;
 
 	/** Dispatched when playhead reached first frame of sequence */
@@ -1214,7 +1215,7 @@ package com.catalystapps.gaf.display
 		{
 			use namespace gaf_internal;
 
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -1226,7 +1227,7 @@ package com.catalystapps.gaf.display
 		{
 			use namespace gaf_internal;
 
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -1238,7 +1239,7 @@ package com.catalystapps.gaf.display
 		{
 			use namespace gaf_internal;
 
-			if (!isNaN(this.__debugOriginalAlpha))
+			if (!MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.alpha = this.__debugOriginalAlpha;
 				this.__debugOriginalAlpha = NaN;

--- a/gaf/src/com/catalystapps/gaf/display/GAFScale9Image.as
+++ b/gaf/src/com/catalystapps/gaf/display/GAFScale9Image.as
@@ -545,7 +545,7 @@ package com.catalystapps.gaf.display
 		gaf_internal function __debugHighlight(): void
 		{
 			use namespace gaf_internal;
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -555,7 +555,7 @@ package com.catalystapps.gaf.display
 		gaf_internal function __debugLowlight(): void
 		{
 			use namespace gaf_internal;
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -565,7 +565,7 @@ package com.catalystapps.gaf.display
 		gaf_internal function __debugResetLight(): void
 		{
 			use namespace gaf_internal;
-			if (!isNaN(this.__debugOriginalAlpha))
+			if (!MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.alpha = this.__debugOriginalAlpha;
 				this.__debugOriginalAlpha = NaN;

--- a/gaf/src/com/catalystapps/gaf/display/GAFTextField.as
+++ b/gaf/src/com/catalystapps/gaf/display/GAFTextField.as
@@ -9,6 +9,7 @@ package com.catalystapps.gaf.display
 	import com.catalystapps.gaf.data.config.CTextFieldObject;
 	import com.catalystapps.gaf.filter.GAFFilter;
 	import com.catalystapps.gaf.utils.DebugUtility;
+	import com.catalystapps.gaf.utils.MathUtility;
 
 	import feathers.controls.TextInput;
 	import feathers.controls.text.TextFieldTextEditor;
@@ -79,8 +80,8 @@ package com.catalystapps.gaf.display
 		{
 			super();
 
-			if (isNaN(scale)) scale = 1;
-			if (isNaN(csf)) csf = 1;
+			if (MathUtility.isNaN(scale)) scale = 1;
+			if (MathUtility.isNaN(csf)) csf = 1;
 
 			this._scale = scale;
 			this._csf = csf;
@@ -90,12 +91,12 @@ package com.catalystapps.gaf.display
 			this._pivotMatrix.ty = config.pivotPoint.y;
 			this._pivotMatrix.scale(scale, scale);
 
-			if (!isNaN(config.width))
+			if (!MathUtility.isNaN(config.width))
 			{
 				this.width = config.width;
 			}
 
-			if (!isNaN(config.height))
+			if (!MathUtility.isNaN(config.height))
 			{
 				this.height = config.height;
 			}
@@ -252,7 +253,7 @@ package com.catalystapps.gaf.display
 				{
 					(this.textEditor as GAFTextFieldTextEditor).setFilterConfig(this._filterConfig, this._filterScale);
 				}
-				else if (this._filterConfig && !isNaN(this._filterScale))
+				else if (this._filterConfig && !MathUtility.isNaN(this._filterScale))
 				{
 					var gafFilter: GAFFilter;
 					if (this.filter)
@@ -287,7 +288,7 @@ package com.catalystapps.gaf.display
 		gaf_internal function __debugHighlight(): void
 		{
 			use namespace gaf_internal;
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -298,7 +299,7 @@ package com.catalystapps.gaf.display
 		gaf_internal function __debugLowlight(): void
 		{
 			use namespace gaf_internal;
-			if (isNaN(this.__debugOriginalAlpha))
+			if (MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.__debugOriginalAlpha = this.alpha;
 			}
@@ -309,7 +310,7 @@ package com.catalystapps.gaf.display
 		gaf_internal function __debugResetLight(): void
 		{
 			use namespace gaf_internal;
-			if (!isNaN(this.__debugOriginalAlpha))
+			if (!MathUtility.isNaN(this.__debugOriginalAlpha))
 			{
 				this.alpha = this.__debugOriginalAlpha;
 				this.__debugOriginalAlpha = NaN;

--- a/gaf/src/com/catalystapps/gaf/utils/MathUtility.as
+++ b/gaf/src/com/catalystapps/gaf/utils/MathUtility.as
@@ -19,6 +19,7 @@ package com.catalystapps.gaf.utils
 			return Math.abs(a - b) < epsilon;
 		}
 
+		[Inline]
 		public static function getItemIndex(source: Vector.<Number>, target: Number): int
 		{
 			for (var i: int = 0; i < source.length; i++)
@@ -29,6 +30,12 @@ package com.catalystapps.gaf.utils
 				}
 			}
 			return -1;
+		}
+
+		[Inline]
+		public static function isNaN(value: Number): Boolean
+		{
+			return value != value;
 		}
 	}
 }


### PR DESCRIPTION
Standard `isNaN` function creates new `MethodClosure` instance on each call, so I wrote simple replacement which does not allocate any memory.
